### PR TITLE
Disable the category select when no monster is selected

### DIFF
--- a/ui/src/screens/monsters/MonsterSelector.tsx
+++ b/ui/src/screens/monsters/MonsterSelector.tsx
@@ -38,6 +38,7 @@ const MonsterSelector: React.FunctionComponent = () => {
                 </Grid>
                 <Grid item xs={4}>
                     <Select
+                        isDisabled={!monster}
                         value={mapCategoryToOption(
                             categories.find(category => category.id === monster?.category?.toLowerCase())
                         )}


### PR DESCRIPTION
Closes #12

Disable category select when no monster is selected